### PR TITLE
fix: select initial tag

### DIFF
--- a/packages/deprecation-crawler/sandbox/deprecation-crawler.config.json
+++ b/packages/deprecation-crawler/sandbox/deprecation-crawler.config.json
@@ -13,6 +13,7 @@
     { "key": "comment-style", "matchers": ["comment-style"] },
     { "key": "catch-all", "matchers": ["(.*?)"] }
   ],
+  "configPath": "deprecation-crawler.config.json",
   "outputDirectory": "./deprecations",
   "tsConfigPath": "tsconfig.sandbox.json",
   "deprecationComment": "@deprecated",

--- a/packages/deprecation-crawler/sandbox/deprecations/.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/.md
@@ -1,4 +1,4 @@
-# master (sandbox-date)
+#  (sandbox-date)
 
 ## all-lowercase
 
@@ -31,6 +31,63 @@ const lowercase2 = 0;
 
 ```ts
 const lowercase3 = 0;
+```
+## comment-style
+
+### crawled.ts
+
+#### foo (FunctionDeclaration) {#3397214801}
+
+@deprecated comment-style single line deprecation
+
+```ts
+function foo() {
+  return 'foo';
+}
+```
+
+#### foo2 (FunctionDeclaration) {#456802929}
+
+@nocollapse
+  @deprecated comment-style deprecation with leading text
+
+```ts
+function foo2() {
+  return 'foo2';
+}
+```
+
+#### foo3 (FunctionDeclaration) {#242198417}
+
+This is foo3
+  @method foo3
+  @deprecated comment-style deprecation with leading and trailing text
+  @return {void}
+
+```ts
+function foo3() {
+  return 'foo3';
+}
+```
+
+#### foo4 (FunctionDeclaration) {#2601492017}
+
+@deprecated comment-style single line deprecation with no space at the end
+
+```ts
+function foo4() {
+  return 'foo4';
+}
+```
+
+#### foo5 (FunctionDeclaration) {#2711487569}
+
+// @deprecated comment-style a non-jsdoc comment
+
+```ts
+function foo5() {
+  return 'foo5';
+}
 ```
 ## catch-all
 

--- a/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
@@ -1,9 +1,47 @@
 <!-- ruid-groups
 
-- master: 
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/multiple-string-patterns-at-once\crawled.ts#15
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/multiple-string-patterns-at-once\crawled.ts#21
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/multiple-string-patterns-at-once\crawled.ts#27
+- : 
+  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L15
+  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L21
+  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L27
 
 ruid-groups -->
 
+
+
+
+# catch-all
+
+Some general information what all there deprecations have in common.
+
+## Things affected by this Change:
+- [methodName](url)
+- [methodName](url)
+
+## Reason
+Short explanation of why the deprecation got introduced
+
+## Implication
+This section is an explanation that accompanies the 'before deprecation' and 'after deprecation' snippets.
+It explains the different between the two versions to the user in a detailed way to help the user to spot the differences in code.
+Make sure to also include estimations on when it breaks.
+
+## Refactoring
+Code example showing the situation before the deprecation, and after the deprecation including the versions.
+
+Example:
+
+> introduced in version 6.0.0-alpha4
+> breaking in version 8.0.0
+
+the following version specifier are set for the rxjs dependencies in StackBlitz:
+
+**Example Before: <6.0.0-alpha4**
+```ts
+// code here
+```
+
+**Example After: >=6.0.0-alpha4 <8.0.0**
+```ts
+// code here
+```

--- a/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
@@ -1,16 +1,18 @@
 <!-- ruid-groups
 
 - : 
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L12
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L18
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L24
+  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L6
+  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L14
+  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L24
+  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L29
+  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L34
 
 ruid-groups -->
 
 
 
 
-# all-lowercase
+# comment-style
 
 Some general information what all there deprecations have in common.
 

--- a/packages/deprecation-crawler/sandbox/deprecations/multiple-string-patterns-at-once.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/multiple-string-patterns-at-once.md
@@ -4,3 +4,41 @@
 
 ruid-groups -->
 
+
+
+
+# multiple-string-patterns-at-once
+
+Some general information what all there deprecations have in common.
+
+## Things affected by this Change:
+- [methodName](url)
+- [methodName](url)
+
+## Reason
+Short explanation of why the deprecation got introduced
+
+## Implication
+This section is an explanation that accompanies the 'before deprecation' and 'after deprecation' snippets.
+It explains the different between the two versions to the user in a detailed way to help the user to spot the differences in code.
+Make sure to also include estimations on when it breaks.
+
+## Refactoring
+Code example showing the situation before the deprecation, and after the deprecation including the versions.
+
+Example:
+
+> introduced in version 6.0.0-alpha4
+> breaking in version 8.0.0
+
+the following version specifier are set for the rxjs dependencies in StackBlitz:
+
+**Example Before: <6.0.0-alpha4**
+```ts
+// code here
+```
+
+**Example After: >=6.0.0-alpha4 <8.0.0**
+```ts
+// code here
+```

--- a/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
+++ b/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
@@ -1,5 +1,5 @@
 {
-    "version": "master",
+    "version": "",
     "date": "sandbox-date",
     "deprecations": [
         {
@@ -13,9 +13,10 @@
                 173,
                 311
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3998890672",
-            "group": "all lowercase"
+            "group": "all-lowercase"
         },
         {
             "path": "all-lowercase\\crawled.ts",
@@ -28,9 +29,10 @@
                 338,
                 417
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2129363187",
-            "group": "all lowercase"
+            "group": "all-lowercase"
         },
         {
             "path": "all-lowercase\\crawled.ts",
@@ -43,9 +45,90 @@
                 444,
                 528
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2585813938",
-            "group": "all lowercase"
+            "group": "all-lowercase"
+        },
+        {
+            "path": "deprecation-comments\\crawled.ts",
+            "lineNumber": 6,
+            "name": "foo",
+            "kind": "FunctionDeclaration",
+            "code": "function foo() {\r\n  return 'foo';\r\n}",
+            "deprecationMessage": "/** @deprecated comment-style single line deprecation */",
+            "pos": [
+                73,
+                129
+            ],
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
+            "ruid": "3397214801",
+            "group": "comment-style"
+        },
+        {
+            "path": "deprecation-comments\\crawled.ts",
+            "lineNumber": 14,
+            "name": "foo2",
+            "kind": "FunctionDeclaration",
+            "code": "function foo2() {\r\n  return 'foo2';\r\n}",
+            "deprecationMessage": "/**\r\n * @nocollapse\r\n * @deprecated comment-style deprecation with leading text\r\n */",
+            "pos": [
+                171,
+                255
+            ],
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
+            "ruid": "456802929",
+            "group": "comment-style"
+        },
+        {
+            "path": "deprecation-comments\\crawled.ts",
+            "lineNumber": 24,
+            "name": "foo3",
+            "kind": "FunctionDeclaration",
+            "code": "function foo3() {\r\n  return 'foo3';\r\n}",
+            "deprecationMessage": "/**\r\n * This is foo3\r\n * @method foo3\r\n * @deprecated comment-style deprecation with leading and trailing text\r\n * @return {void}\r\n */",
+            "pos": [
+                299,
+                433
+            ],
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
+            "ruid": "242198417",
+            "group": "comment-style"
+        },
+        {
+            "path": "deprecation-comments\\crawled.ts",
+            "lineNumber": 29,
+            "name": "foo4",
+            "kind": "FunctionDeclaration",
+            "code": "function foo4() {\r\n  return 'foo4';\r\n}",
+            "deprecationMessage": "/** @deprecated comment-style single line deprecation with no space at the end*/",
+            "pos": [
+                477,
+                557
+            ],
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
+            "ruid": "2601492017",
+            "group": "comment-style"
+        },
+        {
+            "path": "deprecation-comments\\crawled.ts",
+            "lineNumber": 34,
+            "name": "foo5",
+            "kind": "FunctionDeclaration",
+            "code": "function foo5() {\r\n  return 'foo5';\r\n}",
+            "deprecationMessage": "// @deprecated comment-style a non-jsdoc comment",
+            "pos": [
+                601,
+                649
+            ],
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
+            "ruid": "2711487569",
+            "group": "comment-style"
         },
         {
             "path": "multiple-string-patterns-at-once\\crawled.ts",
@@ -58,7 +141,8 @@
                 240,
                 459
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "1734398741",
             "group": "catch-all"
         },
@@ -73,7 +157,8 @@
                 494,
                 638
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3477709142",
             "group": "catch-all"
         },
@@ -88,7 +173,8 @@
                 673,
                 823
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2417065367",
             "group": "catch-all"
         },
@@ -103,7 +189,8 @@
                 146,
                 306
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3186155811",
             "group": "whitespace-normalisation"
         },
@@ -118,7 +205,8 @@
                 348,
                 472
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "677771456",
             "group": "whitespace-normalisation"
         },
@@ -133,7 +221,8 @@
                 514,
                 618
             ],
-            "version": "master",
+            "version": "",
+            "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3130163297",
             "group": "whitespace-normalisation"
         }

--- a/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
@@ -1,9 +1,47 @@
 <!-- ruid-groups
 
-- master: 
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/whitespace-normalisation\crawled.ts#12
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/whitespace-normalisation\crawled.ts#18
-  - https://github.com/timdeschryver/deprecation-manager/tree/master/whitespace-normalisation\crawled.ts#24
+- : 
+  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L12
+  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L18
+  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L24
 
 ruid-groups -->
 
+
+
+
+# whitespace-normalisation
+
+Some general information what all there deprecations have in common.
+
+## Things affected by this Change:
+- [methodName](url)
+- [methodName](url)
+
+## Reason
+Short explanation of why the deprecation got introduced
+
+## Implication
+This section is an explanation that accompanies the 'before deprecation' and 'after deprecation' snippets.
+It explains the different between the two versions to the user in a detailed way to help the user to spot the differences in code.
+Make sure to also include estimations on when it breaks.
+
+## Refactoring
+Code example showing the situation before the deprecation, and after the deprecation including the versions.
+
+Example:
+
+> introduced in version 6.0.0-alpha4
+> breaking in version 8.0.0
+
+the following version specifier are set for the rxjs dependencies in StackBlitz:
+
+**Example Before: <6.0.0-alpha4**
+```ts
+// code here
+```
+
+**Example After: >=6.0.0-alpha4 <8.0.0**
+```ts
+// code here
+```

--- a/packages/deprecation-crawler/src/lib/config.ts
+++ b/packages/deprecation-crawler/src/lib/config.ts
@@ -7,8 +7,7 @@ import {
   TSCONFIG_PATH,
   DEPRECATIONS_OUTPUT_DIRECTORY,
 } from './constants';
-import { readFile, updateRepoConfig } from './utils';
-import { execSync } from 'child_process';
+import { readFile, updateRepoConfig, git } from './utils';
 import * as yargs from 'yargs';
 
 export async function getConfig(): Promise<CrawlConfig> {
@@ -44,12 +43,8 @@ export async function getConfig(): Promise<CrawlConfig> {
     .trim();
   // if no param is given it is '' if param with no value is given it is true
   const argTagGiven = argTag !== 'true' && argTag !== '';
-  const defaultTag = 'main';
-  const tagChoices = sortTags(
-    getGitHubBranches(defaultTag),
-    getGitHubTags(),
-    defaultTag
-  );
+  const tagChoices = sortTags(await getGitHubBranches(), await getGitHubTags());
+  const intialTag = await initialTag(tagChoices);
 
   const userConfig: CrawlConfig = await prompt([
     {
@@ -58,8 +53,7 @@ export async function getConfig(): Promise<CrawlConfig> {
       message: `What git tag do you want to crawl?`,
       skip: argTagGiven as any,
       // @NOTICE: by using choices here the initial value has to be typed as number.
-      // However, passing a string works :)
-      initial: (defaultTag as unknown) as number,
+      initial: intialTag,
       choices: tagChoices,
     },
     {
@@ -121,16 +115,10 @@ export function findTsConfigFiles() {
   ];
 }
 
-function sortTags(tags: string[], branches: string[], first: string): string[] {
-  const branchesWithoutFirst = branches.filter((b) => b !== first);
-  const tagsWithoutFirst = tags.filter((b) => b !== first);
-  // prioritize tags before branches
-  // normalize v1.0.0 and v1.0.0
-  return [
-    ...branchesWithoutFirst.sort(innerSort),
-    ...tagsWithoutFirst.sort(innerSort),
-    first,
-  ];
+function sortTags(tags: string[], branches: string[]): string[] {
+  // remove any duplicates
+  const tagsAndBranches = [...new Set([...branches, ...tags])];
+  return tagsAndBranches.sort(innerSort);
 
   function innerSort(a: string, b: string): number {
     const normalizedA = normalizeSemverIfPresent(a);
@@ -155,24 +143,46 @@ function sortTags(tags: string[], branches: string[], first: string): string[] {
   }
 }
 
-export function getGitHubTags(): string[] {
-  return execSync('git tag')
-    .toString()
-    .trim()
-    .split('\n')
-    .map((s) => s.trim())
-    .sort();
-}
-
-export function getGitHubBranches(defaultTag: string): string[] {
-  return [
-    defaultTag,
-    ...execSync('git branch')
-      .toString()
+export async function getGitHubTags(): Promise<string[]> {
+  const branches = await git(['tag']);
+  return (
+    branches
       .trim()
       .split('\n')
       // @TODO remove ugly hack for the `*` char of the current branch
       .map((i) => i.split('* ').join(''))
-      .filter((v) => v !== defaultTag),
-  ].sort();
+      .sort()
+  );
+}
+
+export async function getGitHubBranches(): Promise<string[]> {
+  const branches = await git(['branch']);
+  return (
+    branches
+      .trim()
+      .split('\n')
+      // @TODO remove ugly hack for the `*` char of the current branch
+      .map((i) => i.split('* ').join(''))
+      .sort()
+  );
+}
+
+async function initialTag(tags: string[]) {
+  const currentBranchOrTag = (
+    (await git(['branch', '--show-current'])) ||
+    (await git(['describe', ' --tags --exact-match']))
+  ).trim();
+  if (tags.includes(currentBranchOrTag)) {
+    return tags.indexOf(currentBranchOrTag);
+  }
+
+  if (tags.includes('main')) {
+    return tags.indexOf('main');
+  }
+
+  if (tags.includes('master')) {
+    return tags.indexOf('master');
+  }
+
+  return 0;
 }

--- a/packages/deprecation-crawler/src/lib/config.ts
+++ b/packages/deprecation-crawler/src/lib/config.ts
@@ -41,18 +41,20 @@ export async function getConfig(): Promise<CrawlConfig> {
   )
     .toString()
     .trim();
+
   // if no param is given it is '' if param with no value is given it is true
   const argTagGiven = argTag !== 'true' && argTag !== '';
-  const tagChoices = sortTags(await getGitHubBranches(), await getGitHubTags());
-  const intialTag = await initialTag(tagChoices);
+  const tagChoices = argTagGiven
+    ? [argTag]
+    : sortTags(await getGitHubBranches(), await getGitHubTags());
+  const intialTag = argTagGiven ? 0 : await initialTag(tagChoices);
 
   const userConfig: CrawlConfig = await prompt([
     {
       type: 'select',
       name: 'gitTag',
       message: `What git tag do you want to crawl?`,
-      skip: argTagGiven as any,
-      // @NOTICE: by using choices here the initial value has to be typed as number.
+      skip: argTagGiven,
       initial: intialTag,
       choices: tagChoices,
     },

--- a/packages/deprecation-crawler/tests/index.test.ts
+++ b/packages/deprecation-crawler/tests/index.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as rimraf from 'rimraf';
-import { RAW_DEPRECATION_PATH } from "../src/lib/constants";
+import { RAW_DEPRECATION_PATH } from '../src/lib/constants';
 
 const SANDBOX_PATH = path.join(__dirname, '..', 'sandbox');
 
@@ -34,9 +34,7 @@ beforeAll(async () => {
 });
 
 test('sandbox', async () => {
-  // BUG: format tag to be able to save the file, e.g. pr/foo
-  // const currentGitTag = await git([`branch --show-current`]);
-  const cliOutput = await exec('npm run crawl -- -t master');
+  const cliOutput = await exec(`npm run crawl -- -t master`);
 
   // verify output
   expect(cliOutput).toMatch(/Looking for deprecations/i);


### PR DESCRIPTION
While I was testing the latest version, the tag select choices were acting weird.
Because `main` was used as default tag (which is not a branch/tag in the target repo), there wasn't a tag selected, which looked weird imho.

In this PR we select the current branch/tag (as suggested in the original PR), and use `main` and then `master` as fallback.