### PR TITLE
fix: tag version via CLI

### DIFF
--- a/packages/deprecation-crawler/sandbox/deprecations/all-lowercase.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/all-lowercase.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- : 
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L12
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L18
-  - https://github.com/timdeschryver/find-deprecations/tree//all-lowercase/crawled.ts#L24
+- master: 
+  - https://github.com/timdeschryver/find-deprecations/tree/master/all-lowercase/crawled.ts#L12
+  - https://github.com/timdeschryver/find-deprecations/tree/master/all-lowercase/crawled.ts#L18
+  - https://github.com/timdeschryver/find-deprecations/tree/master/all-lowercase/crawled.ts#L24
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- : 
-  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L15
-  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L21
-  - https://github.com/timdeschryver/find-deprecations/tree//multiple-string-patterns-at-once/crawled.ts#L27
+- master: 
+  - https://github.com/timdeschryver/find-deprecations/tree/master/multiple-string-patterns-at-once/crawled.ts#L15
+  - https://github.com/timdeschryver/find-deprecations/tree/master/multiple-string-patterns-at-once/crawled.ts#L21
+  - https://github.com/timdeschryver/find-deprecations/tree/master/multiple-string-patterns-at-once/crawled.ts#L27
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
@@ -1,11 +1,11 @@
 <!-- ruid-groups
 
-- : 
-  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L6
-  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L14
-  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L24
-  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L29
-  - https://github.com/timdeschryver/find-deprecations/tree//deprecation-comments/crawled.ts#L34
+- master: 
+  - https://github.com/timdeschryver/find-deprecations/tree/master/deprecation-comments/crawled.ts#L6
+  - https://github.com/timdeschryver/find-deprecations/tree/master/deprecation-comments/crawled.ts#L14
+  - https://github.com/timdeschryver/find-deprecations/tree/master/deprecation-comments/crawled.ts#L24
+  - https://github.com/timdeschryver/find-deprecations/tree/master/deprecation-comments/crawled.ts#L29
+  - https://github.com/timdeschryver/find-deprecations/tree/master/deprecation-comments/crawled.ts#L34
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/master.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/master.md
@@ -1,4 +1,4 @@
-#  (sandbox-date)
+# master (sandbox-date)
 
 ## all-lowercase
 

--- a/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
+++ b/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
@@ -1,5 +1,5 @@
 {
-    "version": "",
+    "version": "master",
     "date": "sandbox-date",
     "deprecations": [
         {
@@ -13,7 +13,7 @@
                 173,
                 311
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3998890672",
             "group": "all-lowercase"
@@ -29,7 +29,7 @@
                 338,
                 417
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2129363187",
             "group": "all-lowercase"
@@ -45,7 +45,7 @@
                 444,
                 528
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2585813938",
             "group": "all-lowercase"
@@ -61,7 +61,7 @@
                 73,
                 129
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3397214801",
             "group": "comment-style"
@@ -77,7 +77,7 @@
                 171,
                 255
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "456802929",
             "group": "comment-style"
@@ -93,7 +93,7 @@
                 299,
                 433
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "242198417",
             "group": "comment-style"
@@ -109,7 +109,7 @@
                 477,
                 557
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2601492017",
             "group": "comment-style"
@@ -125,7 +125,7 @@
                 601,
                 649
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2711487569",
             "group": "comment-style"
@@ -141,7 +141,7 @@
                 240,
                 459
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "1734398741",
             "group": "catch-all"
@@ -157,7 +157,7 @@
                 494,
                 638
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3477709142",
             "group": "catch-all"
@@ -173,7 +173,7 @@
                 673,
                 823
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "2417065367",
             "group": "catch-all"
@@ -189,7 +189,7 @@
                 146,
                 306
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3186155811",
             "group": "whitespace-normalisation"
@@ -205,7 +205,7 @@
                 348,
                 472
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "677771456",
             "group": "whitespace-normalisation"
@@ -221,7 +221,7 @@
                 514,
                 618
             ],
-            "version": "",
+            "version": "master",
             "remoteUrl": "https://github.com/timdeschryver/find-deprecations.git\n",
             "ruid": "3130163297",
             "group": "whitespace-normalisation"

--- a/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- : 
-  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L12
-  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L18
-  - https://github.com/timdeschryver/find-deprecations/tree//whitespace-normalisation/crawled.ts#L24
+- master: 
+  - https://github.com/timdeschryver/find-deprecations/tree/master/whitespace-normalisation/crawled.ts#L12
+  - https://github.com/timdeschryver/find-deprecations/tree/master/whitespace-normalisation/crawled.ts#L18
+  - https://github.com/timdeschryver/find-deprecations/tree/master/whitespace-normalisation/crawled.ts#L24
 
 ruid-groups -->
 


### PR DESCRIPTION
Follow-up to #48
That version didn't use the tag if it was passed via the CLI.

I also changed the ordering, because there's a bug with enquirer that if the initial value can't fit in the screen you can't scroll through the list...
Now, it adds the initial tag to the top of the list and the rest of the list is ordered.