### PR TITLE
refactor: store deprecations as an array

### DIFF
--- a/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
+++ b/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
@@ -1,244 +1,240 @@
-{
-    "version": "master",
-    "date": "",
-    "deprecations": [
-        {
-            "path": "all-lowercase/crawled.ts",
-            "lineNumber": 12,
-            "name": "lowercase1",
-            "kind": "VariableStatement",
-            "code": "const lowercase1 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated internal use only\r\n * Example: all lowercase character\r\n * Group name: all lowercase\r\n * Regex: iNternal use onLy\r\n */",
-            "pos": [
-                173,
-                311
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "3998890672",
-            "group": "all-lowercase"
-        },
-        {
-            "path": "all-lowercase/crawled.ts",
-            "lineNumber": 18,
-            "name": "lowercase2",
-            "kind": "VariableStatement",
-            "code": "const lowercase2 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated Internal use only\r\n * Example: One uppercase character\r\n */",
-            "pos": [
-                338,
-                417
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "2129363187",
-            "group": "all-lowercase"
-        },
-        {
-            "path": "all-lowercase/crawled.ts",
-            "lineNumber": 24,
-            "name": "lowercase3",
-            "kind": "VariableStatement",
-            "code": "const lowercase3 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated inteRnal use oNly\r\n * Example: Multiple uppercase character\r\n */",
-            "pos": [
-                444,
-                528
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "2585813938",
-            "group": "all-lowercase"
-        },
-        {
-            "path": "deprecation-comments/crawled.ts",
-            "lineNumber": 6,
-            "name": "foo",
-            "kind": "FunctionDeclaration",
-            "code": "function foo() {\r\n  return 'foo';\r\n}",
-            "deprecationMessage": "/** @deprecated comment-style single line deprecation */",
-            "pos": [
-                73,
-                129
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "3397214801",
-            "group": "comment-style"
-        },
-        {
-            "path": "deprecation-comments/crawled.ts",
-            "lineNumber": 14,
-            "name": "foo2",
-            "kind": "FunctionDeclaration",
-            "code": "function foo2() {\r\n  return 'foo2';\r\n}",
-            "deprecationMessage": "/**\r\n * @nocollapse\r\n * @deprecated comment-style deprecation with leading text\r\n */",
-            "pos": [
-                171,
-                255
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "456802929",
-            "group": "comment-style"
-        },
-        {
-            "path": "deprecation-comments/crawled.ts",
-            "lineNumber": 24,
-            "name": "foo3",
-            "kind": "FunctionDeclaration",
-            "code": "function foo3() {\r\n  return 'foo3';\r\n}",
-            "deprecationMessage": "/**\r\n * This is foo3\r\n * @method foo3\r\n * @deprecated comment-style deprecation with leading and trailing text\r\n * @return {void}\r\n */",
-            "pos": [
-                299,
-                433
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "242198417",
-            "group": "comment-style"
-        },
-        {
-            "path": "deprecation-comments/crawled.ts",
-            "lineNumber": 29,
-            "name": "foo4",
-            "kind": "FunctionDeclaration",
-            "code": "function foo4() {\r\n  return 'foo4';\r\n}",
-            "deprecationMessage": "/** @deprecated comment-style single line deprecation with no space at the end*/",
-            "pos": [
-                477,
-                557
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "2601492017",
-            "group": "comment-style"
-        },
-        {
-            "path": "deprecation-comments/crawled.ts",
-            "lineNumber": 34,
-            "name": "foo5",
-            "kind": "FunctionDeclaration",
-            "code": "function foo5() {\r\n  return 'foo5';\r\n}",
-            "deprecationMessage": "// @deprecated comment-style a non-jsdoc comment",
-            "pos": [
-                601,
-                649
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "2711487569",
-            "group": "comment-style"
-        },
-        {
-            "path": "multiple-string-patterns-at-once/crawled.ts",
-            "lineNumber": 15,
-            "name": "multiPatternMatch1",
-            "kind": "VariableStatement",
-            "code": "const multiPatternMatch1 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated This const named `t` is deprecated. See {@link info} for xyz.\r\n * Example: 3 pattern match\r\n * Group name: multi pattern match\r\n * Regex: /^(?=.*This const named!)(?=.*deprecated!)(?=.*xyz!).../\r\n */",
-            "pos": [
-                240,
-                459
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "1734398741",
-            "group": "catch-all"
-        },
-        {
-            "path": "multiple-string-patterns-at-once/crawled.ts",
-            "lineNumber": 21,
-            "name": "multiPatternMatch2",
-            "kind": "VariableStatement",
-            "code": "const multiPatternMatch2 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated IMPORTANT! This const named `t1` is deprecated. See {@link info} for xyz.\r\n * Example: 3 pattern match with other start\r\n */",
-            "pos": [
-                494,
-                638
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "3477709142",
-            "group": "catch-all"
-        },
-        {
-            "path": "multiple-string-patterns-at-once/crawled.ts",
-            "lineNumber": 27,
-            "name": "multiPatternMatch3",
-            "kind": "VariableStatement",
-            "code": "const multiPatternMatch3 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated This const named `t2` is deprecated. See {@link info} for xyz and related things.\r\n * Example: 3 pattern match with other end\r\n */",
-            "pos": [
-                673,
-                823
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "2417065367",
-            "group": "catch-all"
-        },
-        {
-            "path": "whitespace-normalisation/crawled.ts",
-            "lineNumber": 12,
-            "name": "whitespacesNormalisation1",
-            "kind": "VariableStatement",
-            "code": "const whitespacesNormalisation1 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated This const is deprecated\r\n * Example: single whitespaces\r\n * Group name: whitespace normalisation\r\n * Regex: This  const is  deprecated\r\n */",
-            "pos": [
-                146,
-                306
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "3186155811",
-            "group": "whitespace-normalisation"
-        },
-        {
-            "path": "whitespace-normalisation/crawled.ts",
-            "lineNumber": 18,
-            "name": "whitespacesNormalisation2",
-            "kind": "VariableStatement",
-            "code": "const whitespacesNormalisation2 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated    This  const is deprecated\r\n * Example: start multiple whitespaces and also multiple times inside\r\n */",
-            "pos": [
-                348,
-                472
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "677771456",
-            "group": "whitespace-normalisation"
-        },
-        {
-            "path": "whitespace-normalisation/crawled.ts",
-            "lineNumber": 24,
-            "name": "whitespacesNormalisation3",
-            "kind": "VariableStatement",
-            "code": "const whitespacesNormalisation3 = 0;",
-            "deprecationMessage": "/**\r\n * @deprecated This  const   is    deprecated\r\n * Example: multiple whitespaces multiple times\r\n */",
-            "pos": [
-                514,
-                618
-            ],
-            "version": "master",
-            "remoteUrl": "",
-            "date": "",
-            "ruid": "3130163297",
-            "group": "whitespace-normalisation"
-        }
-    ]
-}
+[
+    {
+        "path": "all-lowercase/crawled.ts",
+        "lineNumber": 12,
+        "name": "lowercase1",
+        "kind": "VariableStatement",
+        "code": "const lowercase1 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated internal use only\r\n * Example: all lowercase character\r\n * Group name: all lowercase\r\n * Regex: iNternal use onLy\r\n */",
+        "pos": [
+            173,
+            311
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "3998890672",
+        "group": "all-lowercase"
+    },
+    {
+        "path": "all-lowercase/crawled.ts",
+        "lineNumber": 18,
+        "name": "lowercase2",
+        "kind": "VariableStatement",
+        "code": "const lowercase2 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated Internal use only\r\n * Example: One uppercase character\r\n */",
+        "pos": [
+            338,
+            417
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "2129363187",
+        "group": "all-lowercase"
+    },
+    {
+        "path": "all-lowercase/crawled.ts",
+        "lineNumber": 24,
+        "name": "lowercase3",
+        "kind": "VariableStatement",
+        "code": "const lowercase3 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated inteRnal use oNly\r\n * Example: Multiple uppercase character\r\n */",
+        "pos": [
+            444,
+            528
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "2585813938",
+        "group": "all-lowercase"
+    },
+    {
+        "path": "deprecation-comments/crawled.ts",
+        "lineNumber": 6,
+        "name": "foo",
+        "kind": "FunctionDeclaration",
+        "code": "function foo() {\r\n  return 'foo';\r\n}",
+        "deprecationMessage": "/** @deprecated comment-style single line deprecation */",
+        "pos": [
+            73,
+            129
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "3397214801",
+        "group": "comment-style"
+    },
+    {
+        "path": "deprecation-comments/crawled.ts",
+        "lineNumber": 14,
+        "name": "foo2",
+        "kind": "FunctionDeclaration",
+        "code": "function foo2() {\r\n  return 'foo2';\r\n}",
+        "deprecationMessage": "/**\r\n * @nocollapse\r\n * @deprecated comment-style deprecation with leading text\r\n */",
+        "pos": [
+            171,
+            255
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "456802929",
+        "group": "comment-style"
+    },
+    {
+        "path": "deprecation-comments/crawled.ts",
+        "lineNumber": 24,
+        "name": "foo3",
+        "kind": "FunctionDeclaration",
+        "code": "function foo3() {\r\n  return 'foo3';\r\n}",
+        "deprecationMessage": "/**\r\n * This is foo3\r\n * @method foo3\r\n * @deprecated comment-style deprecation with leading and trailing text\r\n * @return {void}\r\n */",
+        "pos": [
+            299,
+            433
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "242198417",
+        "group": "comment-style"
+    },
+    {
+        "path": "deprecation-comments/crawled.ts",
+        "lineNumber": 29,
+        "name": "foo4",
+        "kind": "FunctionDeclaration",
+        "code": "function foo4() {\r\n  return 'foo4';\r\n}",
+        "deprecationMessage": "/** @deprecated comment-style single line deprecation with no space at the end*/",
+        "pos": [
+            477,
+            557
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "2601492017",
+        "group": "comment-style"
+    },
+    {
+        "path": "deprecation-comments/crawled.ts",
+        "lineNumber": 34,
+        "name": "foo5",
+        "kind": "FunctionDeclaration",
+        "code": "function foo5() {\r\n  return 'foo5';\r\n}",
+        "deprecationMessage": "// @deprecated comment-style a non-jsdoc comment",
+        "pos": [
+            601,
+            649
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "2711487569",
+        "group": "comment-style"
+    },
+    {
+        "path": "multiple-string-patterns-at-once/crawled.ts",
+        "lineNumber": 15,
+        "name": "multiPatternMatch1",
+        "kind": "VariableStatement",
+        "code": "const multiPatternMatch1 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated This const named `t` is deprecated. See {@link info} for xyz.\r\n * Example: 3 pattern match\r\n * Group name: multi pattern match\r\n * Regex: /^(?=.*This const named!)(?=.*deprecated!)(?=.*xyz!).../\r\n */",
+        "pos": [
+            240,
+            459
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "1734398741",
+        "group": "catch-all"
+    },
+    {
+        "path": "multiple-string-patterns-at-once/crawled.ts",
+        "lineNumber": 21,
+        "name": "multiPatternMatch2",
+        "kind": "VariableStatement",
+        "code": "const multiPatternMatch2 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated IMPORTANT! This const named `t1` is deprecated. See {@link info} for xyz.\r\n * Example: 3 pattern match with other start\r\n */",
+        "pos": [
+            494,
+            638
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "3477709142",
+        "group": "catch-all"
+    },
+    {
+        "path": "multiple-string-patterns-at-once/crawled.ts",
+        "lineNumber": 27,
+        "name": "multiPatternMatch3",
+        "kind": "VariableStatement",
+        "code": "const multiPatternMatch3 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated This const named `t2` is deprecated. See {@link info} for xyz and related things.\r\n * Example: 3 pattern match with other end\r\n */",
+        "pos": [
+            673,
+            823
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "2417065367",
+        "group": "catch-all"
+    },
+    {
+        "path": "whitespace-normalisation/crawled.ts",
+        "lineNumber": 12,
+        "name": "whitespacesNormalisation1",
+        "kind": "VariableStatement",
+        "code": "const whitespacesNormalisation1 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated This const is deprecated\r\n * Example: single whitespaces\r\n * Group name: whitespace normalisation\r\n * Regex: This  const is  deprecated\r\n */",
+        "pos": [
+            146,
+            306
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "3186155811",
+        "group": "whitespace-normalisation"
+    },
+    {
+        "path": "whitespace-normalisation/crawled.ts",
+        "lineNumber": 18,
+        "name": "whitespacesNormalisation2",
+        "kind": "VariableStatement",
+        "code": "const whitespacesNormalisation2 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated    This  const is deprecated\r\n * Example: start multiple whitespaces and also multiple times inside\r\n */",
+        "pos": [
+            348,
+            472
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "677771456",
+        "group": "whitespace-normalisation"
+    },
+    {
+        "path": "whitespace-normalisation/crawled.ts",
+        "lineNumber": 24,
+        "name": "whitespacesNormalisation3",
+        "kind": "VariableStatement",
+        "code": "const whitespacesNormalisation3 = 0;",
+        "deprecationMessage": "/**\r\n * @deprecated This  const   is    deprecated\r\n * Example: multiple whitespaces multiple times\r\n */",
+        "pos": [
+            514,
+            618
+        ],
+        "version": "master",
+        "remoteUrl": "",
+        "date": "",
+        "ruid": "3130163297",
+        "group": "whitespace-normalisation"
+    }
+]

--- a/packages/deprecation-crawler/src/lib/output-formatters/generate-raw-json.ts
+++ b/packages/deprecation-crawler/src/lib/output-formatters/generate-raw-json.ts
@@ -6,40 +6,27 @@ import { RAW_DEPRECATION_PATH } from '../constants';
 
 export async function generateRawJson(
   config: CrawlConfig,
-  crawledRelease: CrawledRelease,
-  options: { tagDate: string }
+  crawledRelease: CrawledRelease
 ): Promise<void> {
   console.log('📝 Regenerating raw JSON');
 
   ensureDirExists(config.outputDirectory);
 
-  let existingData;
+  let existingDeprecations: Deprecation[] = [];
   try {
     const t = readFileSync(
       join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`)
     );
-    existingData = JSON.parse((t as unknown) as string);
+    existingDeprecations = JSON.parse((t as unknown) as string);
   } catch (e) {
-    existingData = false;
+    existingDeprecations = [];
   }
-  let content;
-  if (existingData) {
-    content = {
-      ...existingData,
-      deprecations: upsertDeprecations(
-        existingData.deprecations,
-        crawledRelease.deprecations
-      ),
-    };
-  } else {
-    content = {
-      version: crawledRelease.tag,
-      date: options.tagDate,
-      deprecations: crawledRelease.deprecations,
-    };
-  }
+  const deprecations = upsertDeprecations(
+    existingDeprecations,
+    crawledRelease.deprecations
+  );
 
-  const json = JSON.stringify(content, null, 4);
+  const json = JSON.stringify(deprecations, null, 4);
   const path = join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`);
   writeFileSync(path, json);
 

--- a/packages/deprecation-crawler/src/lib/processors/add-ruid.ts
+++ b/packages/deprecation-crawler/src/lib/processors/add-ruid.ts
@@ -20,7 +20,7 @@ export function addRuid(config: CrawlConfig): CrawlerProcess {
         deprecations: await generateAndAddRuid(r.deprecations),
       };
     },
-    tap((r) => generateRawJson(config, r, { tagDate: r.date })),
+    tap((r) => generateRawJson(config, r)),
   ]);
 }
 

--- a/packages/deprecation-crawler/src/lib/processors/grouping.ts
+++ b/packages/deprecation-crawler/src/lib/processors/grouping.ts
@@ -22,7 +22,7 @@ export function group(config: CrawlConfig): CrawlerProcess {
       ...r,
       ...(await addGrouping(config, r)),
     }),
-    tap((r) => generateRawJson(config, r, { tagDate: r.date })),
+    tap((r) => generateRawJson(config, r)),
   ]);
 }
 

--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -27,7 +27,7 @@ export function hash(str: string) {
 
 export function ensureDirExists(dir: string) {
   if (!existsSync(dir)) {
-    mkdirSync(dir);
+    mkdirSync(dir, { recursive: true });
   }
 }
 

--- a/packages/deprecation-crawler/tests/index.test.ts
+++ b/packages/deprecation-crawler/tests/index.test.ts
@@ -53,32 +53,30 @@ test('sandbox', async () => {
   });
 
   // verify json
-  const jsonOutput = JSON.parse(
+  const rawDeprecations = JSON.parse(
     fs.readFileSync(
       path.join(SANDBOX_PATH, 'deprecations', RAW_DEPRECATION_PATH),
       'utf8'
     )
   );
 
-  expect(jsonOutput.deprecations).toHaveLength(14);
+  expect(rawDeprecations).toHaveLength(14);
   expect(
-    jsonOutput.deprecations.filter((d) => d.group === 'all-lowercase')
+    rawDeprecations.filter((d) => d.group === 'all-lowercase')
   ).toHaveLength(3);
   expect(
-    jsonOutput.deprecations.filter(
-      (d) => d.group === 'whitespace-normalisation'
-    )
+    rawDeprecations.filter((d) => d.group === 'whitespace-normalisation')
   ).toHaveLength(3);
   // BUG: this has to have 3 hits
   expect(
-    jsonOutput.deprecations.filter(
+    rawDeprecations.filter(
       (d) => d.group === 'multiple-string-patterns-at-once'
     )
   ).toHaveLength(0);
   // BUG: this has to have 0 hits
-  expect(
-    jsonOutput.deprecations.filter((d) => d.group === 'catch-all')
-  ).toHaveLength(3);
+  expect(rawDeprecations.filter((d) => d.group === 'catch-all')).toHaveLength(
+    3
+  );
 }, 60_000);
 
 function exec(command) {


### PR DESCRIPTION
As discussed, in a `Deprecation` we have all the info we need (after the recent changes).
This makes the `version` and `date` property in the raw json obsolete.
This change allows us to append new deprecations to the existing deprecations.

It's also a prerequisite for upcoming features (e.g. untagged deprecations)

There's also a sneak bugfix to create the output directory recursivle, now it would crash if we used `foo/bar/baz/deprecations` as output directory.