### PR TITLE
feat: add nextVersion and untagged deprecations

### DIFF
--- a/packages/deprecation-crawler/sandbox/deprecation-crawler.config.json
+++ b/packages/deprecation-crawler/sandbox/deprecation-crawler.config.json
@@ -19,5 +19,6 @@
   "outputDirectory": "./deprecations",
   "tsConfigPath": "tsconfig.sandbox.json",
   "deprecationComment": "@deprecated",
-  "deprecationLink": "sandbox-deprecation-link"
+  "deprecationLink": "sandbox-deprecation-link",
+  "commentLinkFormat": "Details: {@link ${COMMENT_LINK_URL_TOKEN}#${COMMENT_LINK_URL_PARAM_TOKEN}}"
 }

--- a/packages/deprecation-crawler/sandbox/deprecations/all-lowercase.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/all-lowercase.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- master:
-  - /tree/master/all-lowercase/crawled.ts#L12
-  - /tree/master/all-lowercase/crawled.ts#L18
-  - /tree/master/all-lowercase/crawled.ts#L24
+- :
+  - /tree//all-lowercase/crawled.ts#L12
+  - /tree//all-lowercase/crawled.ts#L18
+  - /tree//all-lowercase/crawled.ts#L24
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/catch-all.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- master:
-  - /tree/master/multiple-string-patterns-at-once/crawled.ts#L15
-  - /tree/master/multiple-string-patterns-at-once/crawled.ts#L21
-  - /tree/master/multiple-string-patterns-at-once/crawled.ts#L27
+- :
+  - /tree//multiple-string-patterns-at-once/crawled.ts#L15
+  - /tree//multiple-string-patterns-at-once/crawled.ts#L21
+  - /tree//multiple-string-patterns-at-once/crawled.ts#L27
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/comment-style.md
@@ -1,11 +1,11 @@
 <!-- ruid-groups
 
-- master:
-  - /tree/master/deprecation-comments/crawled.ts#L6
-  - /tree/master/deprecation-comments/crawled.ts#L14
-  - /tree/master/deprecation-comments/crawled.ts#L24
-  - /tree/master/deprecation-comments/crawled.ts#L29
-  - /tree/master/deprecation-comments/crawled.ts#L34
+- :
+  - /tree//deprecation-comments/crawled.ts#L6
+  - /tree//deprecation-comments/crawled.ts#L14
+  - /tree//deprecation-comments/crawled.ts#L24
+  - /tree//deprecation-comments/crawled.ts#L29
+  - /tree//deprecation-comments/crawled.ts#L34
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
+++ b/packages/deprecation-crawler/sandbox/deprecations/raw-deprecations.json
@@ -10,7 +10,7 @@
             173,
             311
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "3998890672",
@@ -27,7 +27,7 @@
             338,
             417
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "2129363187",
@@ -44,7 +44,7 @@
             444,
             528
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "2585813938",
@@ -61,7 +61,7 @@
             73,
             129
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "3397214801",
@@ -78,7 +78,7 @@
             171,
             255
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "456802929",
@@ -95,7 +95,7 @@
             299,
             433
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "242198417",
@@ -112,7 +112,7 @@
             477,
             557
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "2601492017",
@@ -129,7 +129,7 @@
             601,
             649
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "2711487569",
@@ -146,7 +146,7 @@
             240,
             459
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "1734398741",
@@ -163,7 +163,7 @@
             494,
             638
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "3477709142",
@@ -180,7 +180,7 @@
             673,
             823
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "2417065367",
@@ -197,7 +197,7 @@
             146,
             306
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "3186155811",
@@ -214,7 +214,7 @@
             348,
             472
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "677771456",
@@ -231,7 +231,7 @@
             514,
             618
         ],
-        "version": "master",
+        "version": "5.4.2",
         "remoteUrl": "",
         "date": "",
         "ruid": "3130163297",

--- a/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
+++ b/packages/deprecation-crawler/sandbox/deprecations/whitespace-normalisation.md
@@ -1,9 +1,9 @@
 <!-- ruid-groups
 
-- master:
-  - /tree/master/whitespace-normalisation/crawled.ts#L12
-  - /tree/master/whitespace-normalisation/crawled.ts#L18
-  - /tree/master/whitespace-normalisation/crawled.ts#L24
+- :
+  - /tree//whitespace-normalisation/crawled.ts#L12
+  - /tree//whitespace-normalisation/crawled.ts#L18
+  - /tree//whitespace-normalisation/crawled.ts#L24
 
 ruid-groups -->
 

--- a/packages/deprecation-crawler/src/lib/crawler/index.ts
+++ b/packages/deprecation-crawler/src/lib/crawler/index.ts
@@ -79,8 +79,7 @@ function crawlFileForDeprecations(
             deprecation.comment.range.compilerObject.pos,
             deprecation.comment.range.compilerObject.end,
           ],
-          // @TODO consider storing the tag directly
-          version: crawledRelease.tag,
+          version: '',
           // @TODO consider moving it tothe formatting step and keep the deprecation obj small.
           remoteUrl: crawledRelease.remoteUrl,
           date: crawledRelease.date,

--- a/packages/deprecation-crawler/src/lib/deprecation-crawler.ts
+++ b/packages/deprecation-crawler/src/lib/deprecation-crawler.ts
@@ -1,7 +1,7 @@
 import { getConfig } from './config';
 import { CrawledRelease } from './models';
 import { stripIndent } from 'common-tags';
-import { branchHasChanges, run } from './utils';
+import { branchHasChanges, getVersion, run } from './utils';
 import { logError } from './log';
 import { checkout } from './tasks/checkout';
 import { crawl } from './tasks/crawl';
@@ -10,6 +10,7 @@ import { addGroups } from './tasks/add-groups';
 import { generateOutput } from './tasks/generate-output';
 import { commitChanges } from './tasks/commit-changes';
 import { CRAWLER_MODES } from './constants';
+import { addVersion } from './tasks/add-version';
 
 (async () => {
   await guardAgainstDirtyRepo();
@@ -19,6 +20,7 @@ import { CRAWLER_MODES } from './constants';
   const tasks = [
     checkout,
     crawl,
+    addVersion,
     addGroups,
     generateOutput,
     updateRepository,
@@ -26,7 +28,9 @@ import { CRAWLER_MODES } from './constants';
   ];
 
   // Run all processors
-  const initial = ({} as unknown) as CrawledRelease;
+  const initial = {
+    version: getVersion(),
+  } as CrawledRelease;
   run(tasks, config)(initial);
 })();
 

--- a/packages/deprecation-crawler/src/lib/models.ts
+++ b/packages/deprecation-crawler/src/lib/models.ts
@@ -84,6 +84,7 @@ export interface RawDeprecation {
 
 export interface CrawledRelease {
   tag: string;
+  version: string;
   date: string;
   remoteUrl: string;
   deprecations: Deprecation[];

--- a/packages/deprecation-crawler/src/lib/output-formatters/generate-raw-json.ts
+++ b/packages/deprecation-crawler/src/lib/output-formatters/generate-raw-json.ts
@@ -1,8 +1,9 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
 import { CrawlConfig, CrawledRelease, Deprecation } from '../models';
-import { ensureDirExists } from '../utils';
-import { RAW_DEPRECATION_PATH } from '../constants';
+import {
+  ensureDirExists,
+  readRawDeprecations,
+  writeRawDeprecations,
+} from '../utils';
 import * as kleur from 'kleur';
 
 export async function generateRawJson(
@@ -11,23 +12,16 @@ export async function generateRawJson(
 ): Promise<void> {
   ensureDirExists(config.outputDirectory);
 
-  let existingDeprecations: Deprecation[] = [];
-  try {
-    const t = readFileSync(
-      join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`)
-    );
-    existingDeprecations = JSON.parse((t as unknown) as string);
-  } catch (e) {
-    existingDeprecations = [];
-  }
+  const { deprecations: existingDeprecations, path } = readRawDeprecations(
+    config
+  );
+
   const deprecations = upsertDeprecations(
     existingDeprecations,
     crawledRelease.deprecations
   );
 
-  const json = JSON.stringify(deprecations, null, 4);
-  const path = join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`);
-  writeFileSync(path, json);
+  writeRawDeprecations(deprecations, config);
 
   console.log(kleur.gray(`📝 Raw JSON data up to date under ${path}`));
 }

--- a/packages/deprecation-crawler/src/lib/tasks/add-version.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/add-version.ts
@@ -1,0 +1,46 @@
+import {
+  CrawlConfig,
+  CrawledRelease,
+  CrawlerProcess,
+  Deprecation,
+} from '../models';
+import {
+  concat,
+  readRawDeprecations,
+  tap,
+  writeRawDeprecations,
+} from '../utils';
+
+/**
+ * Adds the version to the (existing and new) deprecations
+ */
+export function addVersion(config: CrawlConfig): CrawlerProcess {
+  return async function (release) {
+    if (!release.version) return release;
+
+    return concat([
+      async (r): Promise<CrawledRelease> => {
+        return {
+          ...r,
+          deprecations: updateVersion(r.deprecations, r.version),
+        };
+      },
+      tap(async (r) => updateExistingDeprecations(config, r.version)),
+    ])(release);
+  };
+}
+
+function updateVersion(
+  rawDeprecations: Deprecation[],
+  version: string
+): Deprecation[] {
+  return rawDeprecations.map((deprecation) => {
+    return { ...deprecation, version: version };
+  });
+}
+
+function updateExistingDeprecations(config: CrawlConfig, version: string) {
+  const { deprecations } = readRawDeprecations(config);
+  const deprecationsWithVersion = updateVersion(deprecations, version);
+  writeRawDeprecations(deprecationsWithVersion, config);
+}

--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -1,14 +1,24 @@
 import * as cp from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { CrawlConfig, CrawlerProcess, CrawledRelease } from './models';
+import {
+  CrawlConfig,
+  CrawlerProcess,
+  CrawledRelease,
+  Deprecation,
+} from './models';
 import {
   format as prettier,
   resolveConfig,
   Options as PrettierOptions,
 } from 'prettier';
-import { CRAWLER_CONFIG_PATH, CRAWLER_MODES } from './constants';
+import {
+  CRAWLER_CONFIG_PATH,
+  CRAWLER_MODES,
+  RAW_DEPRECATION_PATH,
+} from './constants';
 import { prompt } from 'enquirer';
 import * as yargs from 'yargs';
+import { join } from 'path';
 
 export function hash(str: string) {
   const s = str.replace(/ /g, '').replace(/\r\n/g, '\n');
@@ -42,16 +52,54 @@ export function readRepoConfig(): CrawlConfig {
   return JSON.parse(repoConfigFile);
 }
 
+export function readRawDeprecations(config: CrawlConfig) {
+  ensureDirExists(config.outputDirectory);
+  const path = join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`);
+
+  let deprecations: Deprecation[] = [];
+  try {
+    const t = readFileSync(path);
+    deprecations = JSON.parse((t as unknown) as string);
+  } catch (e) {
+    deprecations = [];
+  }
+
+  return { deprecations, path };
+}
+
+export function writeRawDeprecations(
+  deprecations: Deprecation[],
+  config: CrawlConfig
+): void {
+  ensureDirExists(config.outputDirectory);
+  const path = join(config.outputDirectory, `${RAW_DEPRECATION_PATH}`);
+
+  const json = JSON.stringify(deprecations, null, 4);
+  writeFileSync(path, json);
+}
+
+/**
+ * Check for path params from cli command
+ */
 export function getConfigPath() {
-  // Check for path params from cli command
   const argPath = getCliParam(['path', 'p']);
   return argPath ? argPath : CRAWLER_CONFIG_PATH;
 }
 
+/**
+ * Check for verbose params from cli command
+ */
 export function getVerboseFlag() {
-  // Check for path params from cli command
   const argPath = getCliParam(['verbose']);
   return argPath ? argPath : false;
+}
+
+/**
+ * Check for version params from cli command
+ */
+export function getVersion() {
+  const argPath = getCliParam(['next-version', 'v']);
+  return argPath ? argPath : '';
 }
 
 export function formatCode(


### PR DESCRIPTION
- Running without `--nextVersion` adds newly crawled deprecations without a version (`"version": ""`)
- Running with `--nextVersion` adds that version to the newly crawled deprecations
- Running with `--nextVersion` adds that version to the previously crawled deprecations that are untagged

Partially #37