### PR TITLE
fix: skip empty group formatting

### DIFF
--- a/packages/deprecation-crawler/src/lib/crawler/index.ts
+++ b/packages/deprecation-crawler/src/lib/crawler/index.ts
@@ -11,8 +11,7 @@ import { isConstructorDeclaration, isVariableStatement } from 'typescript';
 import { relative } from 'path';
 import { CrawlConfig, CrawledRelease, Deprecation } from '../models';
 import { ensureTsConfigPath } from '../tasks/ensure-tsconfig-path';
-import { getVerboseFlag } from '../utils';
-import * as kleur from 'kleur';
+import { logVerbose } from '../utils';
 
 // What about https://ts-morph.com/details/documentation#js-docs ?
 // Problem: can't find top level deprecations? e.g. merge
@@ -42,9 +41,7 @@ function crawlFileForDeprecations(
       '/'
     );
 
-    if (getVerboseFlag()) {
-      console.log(kleur.gray(`🔎 Looking for deprecations in ${path}`));
-    }
+    logVerbose(`🔎 Looking for deprecations in ${path}`);
     const commentsInFile = getNodesWithCommentsForFile(file);
     const deprecationsInFile = commentsInFile
       .map((p) =>

--- a/packages/deprecation-crawler/src/lib/output-formatters/git/tag-comments.git.formatter.ts
+++ b/packages/deprecation-crawler/src/lib/output-formatters/git/tag-comments.git.formatter.ts
@@ -10,7 +10,7 @@ import {
   COMMENT_LINK_URL_TOKEN,
 } from '../../constants';
 import { ensureCommentLinkFormat } from '../../tasks/ensure-comment-link-template';
-import { getVerboseFlag } from '../../utils';
+import { logVerbose } from '../../utils';
 
 export async function generateTaggedCommentsInRepository(
   config: CrawlConfig,
@@ -30,9 +30,7 @@ export async function generateTaggedCommentsInRepository(
   }, {} as { [filePath: string]: Deprecation[] });
 
   Object.entries(deprecationsByFile).forEach(([path, deprecations]) => {
-    if (getVerboseFlag()) {
-      console.log(kleur.gray(`🔧 ${path}`));
-    }
+    logVerbose(`🔧 ${path}`);
 
     let addedPosForText = 0;
 

--- a/packages/deprecation-crawler/src/lib/output-formatters/markdown/group-based.md.formatter.ts
+++ b/packages/deprecation-crawler/src/lib/output-formatters/markdown/group-based.md.formatter.ts
@@ -1,5 +1,5 @@
 import { CrawlConfig, CrawledRelease, Deprecation } from '../../models';
-import { readFile, formatCode } from '../../utils';
+import { readFile, formatCode, getVerboseFlag } from '../../utils';
 import { writeFileSync } from 'fs';
 import * as path from 'path';
 import { EOL } from 'os';
@@ -39,6 +39,12 @@ export async function updateGroupMd(
         ],
       };
     }, {});
+
+  if (Object(groupedDeprecationsByFileAndTag).keys().length <= 0) {
+    if (getVerboseFlag()) {
+      console.log(`Skipped group ${group.key} as it is empty`);
+    }
+  }
 
   const filePath = path.join(config.outputDirectory, group.key + '.md');
   const fileContent: string = readFile(filePath);

--- a/packages/deprecation-crawler/src/lib/output-formatters/markdown/group-based.md.formatter.ts
+++ b/packages/deprecation-crawler/src/lib/output-formatters/markdown/group-based.md.formatter.ts
@@ -1,5 +1,5 @@
 import { CrawlConfig, CrawledRelease, Deprecation } from '../../models';
-import { readFile, formatCode, getVerboseFlag } from '../../utils';
+import { formatCode, logVerbose, readFile } from '../../utils';
 import { writeFileSync } from 'fs';
 import * as path from 'path';
 import { EOL } from 'os';
@@ -40,10 +40,9 @@ export async function updateGroupMd(
       };
     }, {});
 
-  if (Object(groupedDeprecationsByFileAndTag).keys().length <= 0) {
-    if (getVerboseFlag()) {
-      console.log(`Skipped group ${group.key} as it is empty`);
-    }
+  if (Object.keys(groupedDeprecationsByFileAndTag).length <= 0) {
+    logVerbose(`Skipped group ${group.key} as it is empty`);
+    return Promise.resolve();
   }
 
   const filePath = path.join(config.outputDirectory, group.key + '.md');

--- a/packages/deprecation-crawler/src/lib/tasks/ensure-tsconfig-path.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/ensure-tsconfig-path.ts
@@ -3,23 +3,20 @@ import { prompt } from 'enquirer';
 import { normalize } from 'path';
 import {
   getConfigPath,
-  getVerboseFlag,
   isCrawlerModeSandbox,
+  logVerbose,
   updateRepoConfig,
 } from '../utils';
 import { glob } from 'glob';
 import * as fs from 'fs';
 import { existsSync } from 'fs';
-import * as kleur from 'kleur';
 
 export async function ensureTsConfigPath(
   config: CrawlConfig
 ): Promise<CrawlConfig> {
   // If a tsconfig files is already set proceed
   if (fileExists(config.tsConfigPath)) {
-    if (getVerboseFlag()) {
-      console.log(kleur.gray(`Running with tsconfig: ${config.tsConfigPath}`));
-    }
+    logVerbose(`Running with tsconfig: ${config.tsConfigPath}`);
     return config;
   }
 

--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -43,13 +43,7 @@ export function proxyMethodToggles<T>(
             if (condition()) {
               return origMethod.apply(this, args);
             }
-            if (getVerboseFlag()) {
-              console.log(
-                kleur.gray(
-                  `Call of method ${propKey} got ignored through toggle.`
-                )
-              );
-            }
+            logVerbose(`Call of method ${propKey} got ignored through toggle.`);
             return Promise.resolve();
           }
           return origMethod.apply(this, args);
@@ -122,7 +116,7 @@ export function writeRawDeprecations(
 /**
  * Check for path params from cli command
  */
-export function getConfigPath() {
+export function getConfigPath(): string {
   const argPath = getCliParam(['path', 'p']);
   return argPath ? argPath : CRAWLER_CONFIG_PATH;
 }
@@ -130,16 +124,22 @@ export function getConfigPath() {
 /**
  * Check for verbose params from cli command
  */
-export function getVerboseFlag() {
-  const argPath = getCliParam(['verbose']);
-  return argPath ? argPath : false;
+export function getVerboseFlag(): boolean {
+  const argPath = getCliParam(['verbose', 'v']);
+  return !!argPath;
+}
+
+export function logVerbose(message: string, enforceLog = false): void {
+  if (getVerboseFlag() || enforceLog) {
+    return console.log(kleur.gray(message));
+  }
 }
 
 /**
  * Check for version params from cli command
  */
-export function getVersion() {
-  const argPath = getCliParam(['next-version', 'v']);
+export function getVersion(): string {
+  const argPath = getCliParam(['next-version']);
   return argPath ? argPath : '';
 }
 


### PR DESCRIPTION
Implements `logVerbose` log only in verbose mode of if flag is given
closes #86