### PR TITLE
Implement a path filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "kleur": "^4.0.3",
     "lodash": "^4.17.20",
     "lodash-es": "^4.17.15",
+    "minimatch": "^3.0.4",
     "semver": "^7.3.2",
     "simple-git": "^2.20.1",
     "ts-morph": "^7.1.3",

--- a/packages/deprecation-crawler/src/lib/crawler/index.ts
+++ b/packages/deprecation-crawler/src/lib/crawler/index.ts
@@ -11,7 +11,8 @@ import { isConstructorDeclaration, isVariableStatement } from 'typescript';
 import { relative } from 'path';
 import { CrawlConfig, CrawledRelease, Deprecation } from '../models';
 import { ensureTsConfigPath } from '../tasks/ensure-tsconfig-path';
-import { logVerbose } from '../utils';
+import { getPathFilter, logVerbose } from '../utils';
+import * as minimatch from 'minimatch';
 
 // What about https://ts-morph.com/details/documentation#js-docs ?
 // Problem: can't find top level deprecations? e.g. merge
@@ -24,6 +25,15 @@ export async function crawlDeprecations(
   const deprecations = sourceFiles
     // TODO: seems like these files cannot be parsed correctly?
     .filter((file) => !file.getFilePath().includes('/Observable.ts'))
+    .filter((file) => {
+      console.log(file.getFilePath());
+      return true;
+    })
+    .filter((file) => minimatch(file.getFilePath(), getPathFilter()))
+    .filter((file) => {
+      console.log(file.getFilePath());
+      return true;
+    })
     .map((file) => crawlFileForDeprecations(config, crawledRelease, file))
     .reduce((acc, val) => acc.concat(val), []);
 

--- a/packages/deprecation-crawler/src/lib/crawler/index.ts
+++ b/packages/deprecation-crawler/src/lib/crawler/index.ts
@@ -26,13 +26,8 @@ export async function crawlDeprecations(
     // TODO: seems like these files cannot be parsed correctly?
     .filter((file) => !file.getFilePath().includes('/Observable.ts'))
     .filter((file) => {
-      console.log(file.getFilePath());
-      return true;
-    })
-    .filter((file) => minimatch(file.getFilePath(), getPathFilter()))
-    .filter((file) => {
-      console.log(file.getFilePath());
-      return true;
+      const pathFilter = getPathFilter() || config.pathFilter;
+      return pathFilter ? minimatch(file.getFilePath(), pathFilter) : true;
     })
     .map((file) => crawlFileForDeprecations(config, crawledRelease, file))
     .reduce((acc, val) => acc.concat(val), []);

--- a/packages/deprecation-crawler/src/lib/models.ts
+++ b/packages/deprecation-crawler/src/lib/models.ts
@@ -1,5 +1,6 @@
 export interface CrawlConfig {
   // defaults
+  pathFilter: string;
   tagFormat: string;
   commentLinkFormat: string;
   commitMessage: string;
@@ -9,8 +10,8 @@ export interface CrawlConfig {
   tsConfigPath: string;
   deprecationComment: string;
   deprecationLink: string;
-  // optional fields
   outputDirectory: string;
+  // optional fields
 }
 
 export interface GitTag {

--- a/packages/deprecation-crawler/src/lib/processors/crawl.ts
+++ b/packages/deprecation-crawler/src/lib/processors/crawl.ts
@@ -1,5 +1,5 @@
 import { CrawlConfig, CrawledRelease, CrawlerProcess } from '../models';
-import { concat, tap } from '../utils';
+import { concat, getPathFilter, tap } from '../utils';
 import { crawlDeprecations, getSourceFiles } from '../crawler';
 import { addRuid } from '../tasks/add-ruid';
 import {
@@ -9,6 +9,7 @@ import {
   ProcessFeedback,
 } from '../log';
 import * as kleur from 'kleur';
+import * as minimatch from 'minimatch';
 
 const feedback = getCrawlFeedback();
 
@@ -63,8 +64,23 @@ function getCrawlFeedback(): ProcessFeedback {
         kleur.gray(`Found `),
         kleur.black(`${rawRelease.deprecations.length}`),
         kleur.gray(` in `),
-        kleur.gray(files.length),
+        kleur.black(
+          files
+            // @TODO reuse this logic or better implement it before the .getSourceFiles method is called
+            .filter((file) => {
+              const pathFilter = getPathFilter() || config.pathFilter;
+              return pathFilter
+                ? minimatch(file.getFilePath(), pathFilter)
+                : true;
+            }).length
+        ),
         kleur.gray(` files.`)
+      );
+      console.log(
+        kleur.gray(`Used tsConfig `),
+        kleur.black(`${config.tsConfigPath}`),
+        kleur.gray(` and pathFilter of `),
+        kleur.black(`'${config.pathFilter}'`)
       );
       printFooterLine();
     },

--- a/packages/deprecation-crawler/src/lib/tasks/ensure-config-defaults.ts
+++ b/packages/deprecation-crawler/src/lib/tasks/ensure-config-defaults.ts
@@ -16,6 +16,7 @@ export async function ensureConfigDefaults(
       'groupBasedMarkdown',
       'deprecationIndex',
     ],
+    pathFilter: '',
     tagFormat: TAG_FORMAT_TEMPLATE,
     commitMessage: DEFAULT_COMMIT_MESSAGE,
     commentLinkFormat: DEFAULT_COMMENT_LINK_TEMPLATE,

--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -137,9 +137,9 @@ export function getConfigPath(): string {
 /**
  * Check for path-filter params from cli command
  */
-export function getPathFilter(): string {
+export function getPathFilter(): string | false {
   const argPath = getCliParam(['pathFilter', 'path-filter', 'f']);
-  return argPath && argPath !== 'true' ? argPath : '';
+  return argPath && argPath !== 'true' ? argPath : false;
 }
 
 /**

--- a/packages/deprecation-crawler/src/lib/utils.ts
+++ b/packages/deprecation-crawler/src/lib/utils.ts
@@ -135,6 +135,14 @@ export function getConfigPath(): string {
 }
 
 /**
+ * Check for path-filter params from cli command
+ */
+export function getPathFilter(): string {
+  const argPath = getCliParam(['pathFilter', 'path-filter', 'f']);
+  return argPath && argPath !== 'true' ? argPath : '';
+}
+
+/**
  * Check for verbose params from cli command
  */
 export function getVerboseFlag(): boolean {


### PR DESCRIPTION
This PR implements a path filter as glob pattern.

It is configurable over:
- CLI params
- config object

NOTE: 
I thought about where to implement this logic. Is it a good idea to take if from config/cli and add it to the includes section of our tsConfig file? Will the matching files still get included? Also, you may have other opinions on that case... 

Please let me know.